### PR TITLE
Correggi path assoluti per base path GitHub Pages

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 const CACHE_NAME = 'riformula-v1';
 const ASSETS_TO_CACHE = [
-  '/',
-  '/manifest.webmanifest',
+  '/in_due_tocchi/',
+  '/in_due_tocchi/manifest.webmanifest',
 ];
 
 // Install event - cache assets

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,8 +14,8 @@ import ShareButtons from '../components/ShareButtons.astro';
 
   <title>Riformula</title>
 
-  <link rel="manifest" href="/manifest.webmanifest" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/in_due_tocchi/manifest.webmanifest" />
+  <link rel="icon" type="image/svg+xml" href="/in_due_tocchi/favicon.svg" />
 </head>
 <body class="bg-gray-100 min-h-screen">
   <div class="container mx-auto px-4 py-8 max-w-4xl">
@@ -62,7 +62,7 @@ import ShareButtons from '../components/ShareButtons.astro';
     // Register service worker
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js')
+        navigator.serviceWorker.register('/in_due_tocchi/sw.js')
           .then(registration => {
             console.log('Service Worker registered:', registration);
           })


### PR DESCRIPTION
Correzioni critiche per il funzionamento della PWA su /in_due_tocchi/:
- Aggiorna link manifest: /manifest.webmanifest → /in_due_tocchi/manifest.webmanifest
- Aggiorna link favicon: /favicon.svg → /in_due_tocchi/favicon.svg
- Correggi registrazione service worker: /sw.js → /in_due_tocchi/sw.js
- Aggiorna assets cached nel service worker con base path corretto

Questi path assoluti erano la causa principale del mancato riconoscimento della PWA su Android, perché il browser non riusciva a trovare il manifest.