### PR TITLE
Fix: estrai URL dal campo text su Android

### DIFF
--- a/src/lib/share.js
+++ b/src/lib/share.js
@@ -83,10 +83,25 @@ export function parseSharedData() {
 
   const params = new URLSearchParams(window.location.search);
 
+  let title = params.get('title') || '';
+  let text = params.get('text') || '';
+  let url = params.get('url') || '';
+
+  // Android workaround: if url is empty, try to extract it from text
+  // Many Android apps put the URL in the text field instead of url field
+  if (!url && text) {
+    const urlMatch = text.match(/https?:\/\/[^\s]+/);
+    if (urlMatch) {
+      url = urlMatch[0];
+      // Remove the URL from text to avoid duplication
+      text = text.replace(url, '').trim();
+    }
+  }
+
   return {
-    title: params.get('title') || '',
-    text: params.get('text') || '',
-    url: params.get('url') || ''
+    title,
+    text,
+    url
   };
 }
 


### PR DESCRIPTION
Su Android, molte app (browser, YouTube, etc.) passano l'URL nel campo "text" invece che nel campo "url" durante la condivisione. Questa fix:
- Rileva se url è vuoto e text contiene un URL
- Estrae l'URL dal testo usando regex
- Rimuove l'URL dal campo text per evitare duplicazione

Risolve il problema con il template "Film Filtrati" che non riceveva l'URL.