### PR TITLE
feat: enable free text mode with no default template

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -203,11 +203,6 @@ const templates = (() => {
         button.addEventListener('click', () => selectTemplate(template.id));
 
         templateButtons.appendChild(button);
-
-        if (index === 0) {
-          currentTemplateId = template.id;
-          updateButtonStyles();
-        }
       });
     }
 
@@ -258,11 +253,28 @@ const templates = (() => {
 
     // Update preview text
     function updatePreview() {
-      const template = getTemplate(currentTemplateId);
-      if (!template) return;
+      let result = '';
 
-      const appendUrl = appendUrlCheckbox.checked;
-      const result = applyTemplate(template.template, currentData, appendUrl);
+      if (currentTemplateId) {
+        // Apply selected template
+        const template = getTemplate(currentTemplateId);
+        if (!template) return;
+
+        const appendUrl = appendUrlCheckbox.checked;
+        result = applyTemplate(template.template, currentData, appendUrl);
+      } else {
+        // Free text mode - combine non-empty fields
+        const parts = [];
+        if (currentData.title) parts.push(currentData.title);
+        if (currentData.text) parts.push(currentData.text);
+
+        result = parts.join('\n\n');
+
+        // Add URL if checkbox is checked and URL is provided
+        if (appendUrlCheckbox.checked && currentData.url) {
+          result = result ? result + '\n\n' + currentData.url : currentData.url;
+        }
+      }
 
       previewText.value = result;
       charCount.textContent = `${result.length} caratteri`;


### PR DESCRIPTION
Remove automatic selection of first template on load, allowing users to start with free text mode. When no template is selected, the preview shows title, text, and optionally URL based on checkbox state.

Changes:
- Remove auto-selection of first template in loadTemplates()
- Update updatePreview() to handle null currentTemplateId
- Free text mode concatenates non-empty fields with newlines