### PR TITLE
fix: implement PWA cache versioning and update notification

### DIFF
--- a/APP_UPDATE_FIX.md
+++ b/APP_UPDATE_FIX.md
@@ -1,0 +1,81 @@
+# Fix per l'Aggiornamento della PWA su Smartphone
+
+## Problema
+Dopo ogni aggiornamento e pubblicazione su GitHub, l'app su smartphone non si aggiornava perché il Service Worker continuava a servire la versione vecchia dalla cache.
+
+## Soluzione Implementata
+
+### 1. Cache Dinamico con Versioning
+Il Service Worker ora usa un nome cache dinamico che cambia ad ogni build:
+```javascript
+const CACHE_VERSION = '20251107-2050';  // Aggiornato automaticamente
+const CACHE_NAME = `riformula-v${CACHE_VERSION}`;
+```
+
+### 2. Script Automatico di Aggiornamento
+Lo script `update-cache-version.js` aggiorna automaticamente la versione della cache con timestamp prima di ogni build.
+
+### 3. Notifica di Aggiornamento
+Quando una nuova versione è disponibile, l'app mostra un banner in alto con il pulsante "Aggiorna ora" che ricarica l'app.
+
+### 4. Controllo Periodico degli Aggiornamenti
+Il Service Worker controlla automaticamente ogni 5 minuti se ci sono nuove versioni disponibili.
+
+## Come Funziona
+
+1. **Durante il Build**:
+   - Lo script `prebuild` esegue automaticamente `update-cache-version.js`
+   - Il timestamp corrente viene inserito nel Service Worker
+   - Il build procede con la nuova versione cache
+
+2. **Quando l'Utente Visita l'App**:
+   - Il browser scarica il nuovo Service Worker
+   - Il nuovo SW installa la nuova cache
+   - Quando si attiva, cancella le vecchie cache
+   - Invia un messaggio "SW_UPDATED" all'app
+   - L'app mostra il banner di aggiornamento
+
+3. **L'Utente Aggiorna**:
+   - Clicca su "Aggiorna ora"
+   - L'app si ricarica
+   - La nuova versione è attiva
+
+## Uso
+
+### Build Normale
+```bash
+npm run build
+```
+Lo script `prebuild` aggiornerà automaticamente la versione della cache.
+
+### Aggiornamento Manuale della Cache
+Se necessario, puoi aggiornare manualmente la versione:
+```bash
+node update-cache-version.js
+```
+
+## Testing
+
+1. Fai una build e pubblica su GitHub Pages
+2. Apri l'app su smartphone
+3. Fai una modifica al codice
+4. Fai una nuova build e pubblica
+5. Riapri l'app su smartphone
+6. Dovresti vedere il banner "Nuova versione disponibile!"
+7. Clicca "Aggiorna ora"
+8. L'app si ricarica con la nuova versione
+
+## Note Tecniche
+
+- **Cache Busting**: Ogni build ha un timestamp unico nel formato `YYYYMMDD-HHmm`
+- **Skip Waiting**: Il nuovo SW si attiva immediatamente
+- **Clients Claim**: Il nuovo SW prende controllo di tutte le pagine aperte
+- **Update Check**: Controlla aggiornamenti ogni 5 minuti
+- **Old Cache Cleanup**: Le vecchie cache vengono eliminate automaticamente
+
+## File Modificati
+
+- `public/sw.js` - Service Worker con versioning dinamico
+- `src/pages/index.astro` - Aggiunto banner di aggiornamento e listener
+- `update-cache-version.js` - Script di aggiornamento automatico della versione
+- `package.json` - Aggiunto script `prebuild`

--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,13 @@
 ## 2025-11-07
 
+**Fixed PWA update mechanism for smartphones**
+- Implementato cache versioning dinamico basato su timestamp
+- Creato script automatico `update-cache-version.js` che aggiorna la versione cache ad ogni build
+- Aggiunto banner di notifica "Nuova versione disponibile" con pulsante reload
+- Service Worker ora controlla aggiornamenti ogni 5 minuti
+- Risolto problema di app non aggiornata dopo push su GitHub
+- Vedi `APP_UPDATE_FIX.md` per dettagli tecnici completi
+
 **Updated Film template**
 - Aggiunto ordinamento decrescente per voto IMDb
 - Precisato filtro esclusivo per Amazon Prime Video e Netflix

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "prebuild": "node update-cache-version.js",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -70,6 +70,19 @@ const templates = (() => {
     </div>
   </div>
 
+  <!-- Update Notification Banner -->
+  <div id="update-banner" class="fixed top-0 left-0 right-0 bg-blue-500 text-white p-4 shadow-lg z-40 hidden">
+    <div class="container mx-auto flex items-center justify-between max-w-4xl">
+      <div class="flex items-center gap-3">
+        <span class="text-2xl">🔄</span>
+        <span class="font-medium">Nuova versione disponibile!</span>
+      </div>
+      <button id="reload-app" class="bg-white text-blue-500 px-4 py-2 rounded-lg font-medium hover:bg-blue-50 transition-colors">
+        Aggiorna ora
+      </button>
+    </div>
+  </div>
+
   <script is:inline set:html={`
     // Templates loaded at build time, embedded as JSON
     // Using direct JSON assignment instead of define:vars for better Android compatibility
@@ -99,12 +112,40 @@ const templates = (() => {
         navigator.serviceWorker.register('/in_due_tocchi/sw.js')
           .then(registration => {
             console.log('Service Worker registered:', registration);
+
+            // Check for updates periodically (every 5 minutes)
+            setInterval(() => {
+              registration.update();
+            }, 5 * 60 * 1000);
           })
           .catch(error => {
             console.error('Service Worker registration failed:', error);
           });
       });
+
+      // Listen for service worker updates
+      navigator.serviceWorker.addEventListener('message', (event) => {
+        if (event.data && event.data.type === 'SW_UPDATED') {
+          console.log('New version available:', event.data.version);
+          showUpdateBanner();
+        }
+      });
     }
+
+    // Show update banner
+    function showUpdateBanner() {
+      const banner = document.getElementById('update-banner');
+      if (banner) {
+        banner.classList.remove('hidden');
+      }
+    }
+
+    // Reload app button handler
+    document.addEventListener('click', (e) => {
+      if (e.target.id === 'reload-app') {
+        window.location.reload();
+      }
+    });
 
     // Device detection and modal logic
     function isAndroidMobile() {

--- a/update-cache-version.js
+++ b/update-cache-version.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/**
+ * Updates the service worker cache version with current timestamp
+ * Run this before each build to ensure cache busting
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SW_PATH = join(__dirname, 'public', 'sw.js');
+
+try {
+  // Read service worker file
+  let swContent = readFileSync(SW_PATH, 'utf8');
+
+  // Generate new version string (YYYYMMDD-HHmm format)
+  const now = new Date();
+  const version = now.toISOString()
+    .replace(/[-:]/g, '')
+    .replace('T', '-')
+    .substring(0, 13);
+
+  // Update CACHE_VERSION line
+  swContent = swContent.replace(
+    /const CACHE_VERSION = '[^']+';/,
+    `const CACHE_VERSION = '${version}';`
+  );
+
+  // Write back to file
+  writeFileSync(SW_PATH, swContent, 'utf8');
+
+  console.log(`✅ Cache version updated to: ${version}`);
+} catch (error) {
+  console.error('❌ Error updating cache version:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Problem:
After publishing updates to GitHub, the PWA on smartphones didn't update because the service worker continued serving the old cached version.

Solution:
1. Dynamic cache versioning based on timestamps
   - Cache name now includes build timestamp (e.g., 'riformula-v20251107-2050')
   - Each build generates a unique cache version

2. Automatic version update script
   - Created update-cache-version.js to auto-update cache version
   - Integrated as prebuild script in package.json
   - Runs before every build automatically

3. Update notification banner
   - Blue banner at top of page when new version is available
   - "Aggiorna ora" button to reload and apply updates
   - Service worker sends SW_UPDATED message to clients

4. Periodic update checks
   - Service worker checks for updates every 5 minutes
   - Ensures users get latest version without manual refresh

Technical changes:
- public/sw.js: Dynamic CACHE_VERSION, update notifications
- src/pages/index.astro: Update banner UI and listener logic
- update-cache-version.js: Automatic version update script
- package.json: Added prebuild script
- APP_UPDATE_FIX.md: Complete technical documentation
- LOG.md: Updated with fix details

Testing:
1. Build and deploy to GitHub Pages
2. Open app on smartphone
3. Make changes and redeploy
4. App will show "Nuova versione disponibile!" banner
5. Click "Aggiorna ora" to get latest version