### PR TITLE
Disabilita i pulsanti condividi e copia quando il campo URL è vuoto

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // Dynamic cache name based on timestamp - changes with each deployment
-const CACHE_VERSION = '20251113-0644';  // Update this with each deployment
+const CACHE_VERSION = '20251113-2324';  // Update this with each deployment
 const CACHE_NAME = `shareforge-v${CACHE_VERSION}`;
 const ASSETS_TO_CACHE = [
   '/in_due_tocchi/',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -589,6 +589,9 @@ const alternateLocales = Object.entries(OG_LOCALES)
         shareBtn.style.display = 'none';
       }
 
+      // Update share buttons state based on URL
+      updateShareButtonsState();
+
       // Show mobile help banner if needed
       if (shouldShowMobileHelp()) {
         showMobileHelp();
@@ -702,6 +705,7 @@ const alternateLocales = Object.entries(OG_LOCALES)
       inputText.value = currentData.text;
       inputUrl.value = currentData.url;
       isPopulating = false;
+      updateShareButtonsState();
     }
 
     // Update current data from inputs
@@ -760,6 +764,33 @@ const alternateLocales = Object.entries(OG_LOCALES)
       }, 3000);
     }
 
+    // Update share buttons state based on URL presence
+    function updateShareButtonsState() {
+      const hasUrl = currentData.url && currentData.url.trim() !== '';
+
+      if (shareBtn) {
+        shareBtn.disabled = !hasUrl;
+        if (!hasUrl) {
+          shareBtn.classList.add('opacity-50', 'cursor-not-allowed');
+          shareBtn.classList.remove('hover:bg-blue-600', 'hover:shadow-md');
+        } else {
+          shareBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+          shareBtn.classList.add('hover:bg-blue-600', 'hover:shadow-md');
+        }
+      }
+
+      if (copyBtn) {
+        copyBtn.disabled = !hasUrl;
+        if (!hasUrl) {
+          copyBtn.classList.add('opacity-50', 'cursor-not-allowed');
+          copyBtn.classList.remove('hover:bg-gray-600', 'hover:shadow-md');
+        } else {
+          copyBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+          copyBtn.classList.add('hover:bg-gray-600', 'hover:shadow-md');
+        }
+      }
+    }
+
 
     // Event listeners
 
@@ -786,6 +817,7 @@ const alternateLocales = Object.entries(OG_LOCALES)
         if (!isPopulating) {
           updateDataFromInputs();
           updatePreview();
+          updateShareButtonsState();
         }
       });
     }


### PR DESCRIPTION
- Aggiunta funzione updateShareButtonsState() per controllare lo stato dei pulsanti
- I pulsanti vengono disabilitati con stile opaco quando l'URL è vuoto
- Lo stato viene aggiornato all'inizializzazione, quando l'URL cambia e quando vengono popolati gli input
- Incrementata versione cache Service Worker